### PR TITLE
Fix broken hyperlinks and asset loading

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -3,7 +3,7 @@ require_once __DIR__ . '/includes/config.php';
 require_once __DIR__ . '/includes/auth.php';
 
 if (!Auth::isLoggedIn()) {
-    header("Location: /login.php");
+    header("Location: " . BASE_URL . "login.php");
     exit;
 }
 
@@ -53,18 +53,18 @@ require_once __DIR__ . '/includes/header.php';
                     <p class="text-muted">Member since <?= date('M Y', strtotime($user['created_at'] ?? 'now')) ?></p>
                     
                     <div class="list-group">
-                        <a href="/report.php" class="list-group-item list-group-item-action">
+                        <a href="<?= BASE_URL ?>report.php" class="list-group-item list-group-item-action">
                             <i class="fas fa-plus-circle mr-2"></i> Report New Threat
                         </a>
-                        <a href="/search.php" class="list-group-item list-group-item-action">
+                        <a href="<?= BASE_URL ?>search.php" class="list-group-item list-group-item-action">
                             <i class="fas fa-search mr-2"></i> Search Threats
                         </a>
                         <?php if (Auth::isAdmin()): ?>
-                            <a href="/admin/dashboard.php" class="list-group-item list-group-item-action">
+                            <a href="<?= BASE_URL ?>admin/dashboard.php" class="list-group-item list-group-item-action">
                                 <i class="fas fa-cog mr-2"></i> Admin Dashboard
                             </a>
                         <?php endif; ?>
-                        <a href="/logout.php" class="list-group-item list-group-item-action text-danger">
+                        <a href="<?= BASE_URL ?>logout.php" class="list-group-item list-group-item-action text-danger">
                             <i class="fas fa-sign-out-alt mr-2"></i> Logout
                         </a>
                     </div>
@@ -91,7 +91,7 @@ require_once __DIR__ . '/includes/header.php';
                     <?php if (empty($recentSubmissions)): ?>
                         <div class="alert alert-info">
                             You haven't submitted any threats yet. 
-                            <a href="/report.php" class="alert-link">Report your first threat</a> to help protect others.
+                            <a href="<?= BASE_URL ?>report.php" class="alert-link">Report your first threat</a> to help protect others.
                         </div>
                     <?php else: ?>
                         <div class="table-responsive">
@@ -108,7 +108,7 @@ require_once __DIR__ . '/includes/header.php';
                                     <?php foreach ($recentSubmissions as $submission): ?>
                                         <tr>
                                             <td>
-                                                <a href="/threats/details.php?id=<?= $submission['threat_id'] ?>">
+                                                <a href="<?= BASE_URL ?>threats/details.php?id=<?= $submission['threat_id'] ?>">
                                                     <?= htmlspecialchars($submission['entity']) ?>
                                                 </a>
                                             </td>
@@ -127,7 +127,7 @@ require_once __DIR__ . '/includes/header.php';
                             </table>
                         </div>
                         <div class="text-right">
-                            <a href="/user/submissions.php" class="btn btn-sm btn-primary">View All</a>
+                            <a href="<?= BASE_URL ?>user/submissions.php" class="btn btn-sm btn-primary">View All</a>
                         </div>
                     <?php endif; ?>
                 </div>
@@ -140,22 +140,22 @@ require_once __DIR__ . '/includes/header.php';
                 <div class="card-body">
                     <div class="row">
                         <div class="col-md-6 mb-3">
-                            <a href="/report.php" class="btn btn-primary btn-block">
+                            <a href="<?= BASE_URL ?>report.php" class="btn btn-primary btn-block">
                                 <i class="fas fa-plus-circle mr-2"></i> Report Threat
                             </a>
                         </div>
                         <div class="col-md-6 mb-3">
-                            <a href="/search.php" class="btn btn-secondary btn-block">
+                            <a href="<?= BASE_URL ?>search.php" class="btn btn-secondary btn-block">
                                 <i class="fas fa-search mr-2"></i> Search Database
                             </a>
                         </div>
                         <div class="col-md-6 mb-3">
-                            <a href="/appeals/submit.php" class="btn btn-warning btn-block">
+                            <a href="<?= BASE_URL ?>appeals/submit.php" class="btn btn-warning btn-block">
                                 <i class="fas fa-gavel mr-2"></i> Submit Appeal
                             </a>
                         </div>
                         <div class="col-md-6 mb-3">
-                            <a href="/user/settings.php" class="btn btn-info btn-block">
+                            <a href="<?= BASE_URL ?>user/settings.php" class="btn btn-info btn-block">
                                 <i class="fas fa-cog mr-2"></i> Account Settings
                             </a>
                         </div>

--- a/includes/config.php
+++ b/includes/config.php
@@ -20,7 +20,26 @@ session_start();
 // Application constants
 define('APP_NAME', 'DTIS');
 define('APP_VERSION', '1.0.0');
-define('BASE_URL', 'http://' . $_SERVER['HTTP_HOST'] . '/DTIS/');
+
+// Dynamic BASE_URL calculation
+$protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
+$host = $_SERVER['HTTP_HOST'];
+// Get the physical path of the project root directory
+$project_root_fs = dirname(__DIR__);
+// Get the physical path of the web server's document root
+$document_root_fs = $_SERVER['DOCUMENT_ROOT'];
+
+// Replace backslashes with forward slashes for Windows compatibility
+$project_root_fs = str_replace('\\', '/', $project_root_fs);
+$document_root_fs = str_replace('\\', '/', $document_root_fs);
+
+// Calculate the URI path by removing the document root from the project root path
+$uri_path = str_replace($document_root_fs, '', $project_root_fs);
+// Ensure there is a single trailing slash
+$uri_path = rtrim($uri_path, '/') . '/';
+
+define('BASE_URL', $protocol . $host . $uri_path);
+
 
 // Security constants
 define('REQUIRED_VERIFICATIONS', 50); // Minimum verifications for auto-approval

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -10,17 +10,17 @@
                     <div class="col-md-4">
                         <h5>Quick Links</h5>
                         <ul class="list-unstyled">
-                            <li><a href="/search.php" class="text-white">Threat Database</a></li>
-                            <li><a href="/report.php" class="text-white">Report a Threat</a></li>
-                            <li><a href="/appeal.php" class="text-white">Submit an Appeal</a></li>
+                            <li><a href="<?= BASE_URL ?>search.php" class="text-white">Threat Database</a></li>
+                            <li><a href="<?= BASE_URL ?>report.php" class="text-white">Report a Threat</a></li>
+                            <li><a href="<?= BASE_URL ?>appeal.php" class="text-white">Submit an Appeal</a></li>
                         </ul>
                     </div>
                     <div class="col-md-4">
                         <h5>Legal</h5>
                         <ul class="list-unstyled">
-                            <li><a href="/terms.php" class="text-white">Terms of Service</a></li>
-                            <li><a href="/privacy.php" class="text-white">Privacy Policy</a></li>
-                            <li><a href="/contact.php" class="text-white">Contact Us</a></li>
+                            <li><a href="<?= BASE_URL ?>terms.php" class="text-white">Terms of Service</a></li>
+                            <li><a href="<?= BASE_URL ?>privacy.php" class="text-white">Privacy Policy</a></li>
+                            <li><a href="<?= BASE_URL ?>contact.php" class="text-white">Contact Us</a></li>
                         </ul>
                     </div>
                 </div>
@@ -31,11 +31,11 @@
         </footer>
         
         <!-- JavaScript -->
-        <script src="/assets/js/main.js"></script>
-        <script src="/assets/js/form-validation.js"></script>
+        <script src="<?= BASE_URL ?>assets/js/main.js"></script>
+        <script src="<?= BASE_URL ?>assets/js/form-validation.js"></script>
         <?php if (isset($additionalJS)): ?>
             <?php foreach ($additionalJS as $jsFile): ?>
-                <script src="/assets/js/<?= $jsFile ?>"></script>
+                <script src="<?= BASE_URL ?>assets/js/<?= $jsFile ?>"></script>
             <?php endforeach; ?>
         <?php endif; ?>
     </body>

--- a/includes/header.php
+++ b/includes/header.php
@@ -12,13 +12,13 @@ if (!isset($pageTitle)) {
     <title><?= htmlspecialchars($pageTitle) ?> | DTIS</title>
     
     <!-- Favicon -->
-    <link rel="icon" href="/assets/images/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="<?= BASE_URL ?>assets/images/favicon.ico" type="image/x-icon">
     
     <!-- CSS -->
-    <link rel="stylesheet" href="/assets/css/main.css">
+    <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/main.css">
     <?php if (isset($additionalCSS)): ?>
         <?php foreach ($additionalCSS as $cssFile): ?>
-            <link rel="stylesheet" href="/assets/css/<?= $cssFile ?>">
+            <link rel="stylesheet" href="<?= BASE_URL ?>assets/css/<?= $cssFile ?>">
         <?php endforeach; ?>
     <?php endif; ?>
     
@@ -33,8 +33,8 @@ if (!isset($pageTitle)) {
         <div class="container">
             <nav class="navbar">
                 <div class="logo">
-                    <a href="/">
-                        <img src="/assets/images/logo.png" alt="DTIS Logo">
+                    <a href="<?= BASE_URL ?>">
+                        <img src="<?= BASE_URL ?>assets/images/logo.png" alt="DTIS Logo">
                         <h1>DTIS</h1>
                     </a>
                 </div>
@@ -44,16 +44,16 @@ if (!isset($pageTitle)) {
                 </button>
                 
                 <ul class="nav-links d-none d-md-flex">
-                    <li><a href="/search.php">Threat Database</a></li>
+                    <li><a href="<?= BASE_URL ?>search.php">Threat Database</a></li>
                     <?php if (Auth::isLoggedIn()): ?>
                         <?php if (Auth::isAdmin()): ?>
-                            <li><a href="/admin/dashboard.php">Admin</a></li>
+                            <li><a href="<?= BASE_URL ?>admin/dashboard.php">Admin</a></li>
                         <?php endif; ?>
-                        <li><a href="/dashboard.php">Dashboard</a></li>
-                        <li><a href="/logout.php">Logout</a></li>
+                        <li><a href="<?= BASE_URL ?>dashboard.php">Dashboard</a></li>
+                        <li><a href="<?= BASE_URL ?>logout.php">Logout</a></li>
                     <?php else: ?>
-                        <li><a href="/login.php">Login</a></li>
-                        <li><a href="/register.php">Register</a></li>
+                        <li><a href="<?= BASE_URL ?>login.php">Login</a></li>
+                        <li><a href="<?= BASE_URL ?>register.php">Register</a></li>
                     <?php endif; ?>
                 </ul>
             </nav>
@@ -61,16 +61,16 @@ if (!isset($pageTitle)) {
             <!-- Mobile Menu -->
             <div id="mobile-menu" class="d-md-none hidden mt-3">
                 <div class="list-group">
-                    <a href="/search.php" class="list-group-item list-group-item-action">Threat Database</a>
+                    <a href="<?= BASE_URL ?>search.php" class="list-group-item list-group-item-action">Threat Database</a>
                     <?php if (Auth::isLoggedIn()): ?>
                         <?php if (Auth::isAdmin()): ?>
-                            <a href="/admin/dashboard.php" class="list-group-item list-group-item-action">Admin</a>
+                            <a href="<?= BASE_URL ?>admin/dashboard.php" class="list-group-item list-group-item-action">Admin</a>
                         <?php endif; ?>
-                        <a href="/dashboard.php" class="list-group-item list-group-item-action">Dashboard</a>
-                        <a href="/logout.php" class="list-group-item list-group-item-action">Logout</a>
+                        <a href="<?= BASE_URL ?>dashboard.php" class="list-group-item list-group-item-action">Dashboard</a>
+                        <a href="<?= BASE_URL ?>logout.php" class="list-group-item list-group-item-action">Logout</a>
                     <?php else: ?>
-                        <a href="/login.php" class="list-group-item list-group-item-action">Login</a>
-                        <a href="/register.php" class="list-group-item list-group-item-action">Register</a>
+                        <a href="<?= BASE_URL ?>login.php" class="list-group-item list-group-item-action">Login</a>
+                        <a href="<?= BASE_URL ?>register.php" class="list-group-item list-group-item-action">Register</a>
                     <?php endif; ?>
                 </div>
             </div>

--- a/index.php
+++ b/index.php
@@ -51,15 +51,15 @@ try {
                         </div>
                     </div>
                 </div>
-                <a href="/search.php" class="btn btn-primary btn-lg mr-3">
+                <a href="<?= BASE_URL ?>search.php" class="btn btn-primary btn-lg mr-3">
                     <i class="fas fa-search"></i> Search Threats
                 </a>
                 <?php if (Auth::isLoggedIn()): ?>
-                    <a href="/dashboard.php" class="btn btn-secondary btn-lg">
+                    <a href="<?= BASE_URL ?>dashboard.php" class="btn btn-secondary btn-lg">
                         <i class="fas fa-tachometer-alt"></i> Dashboard
                     </a>
                 <?php else: ?>
-                    <a href="/register.php" class="btn btn-secondary btn-lg">
+                    <a href="<?= BASE_URL ?>register.php" class="btn btn-secondary btn-lg">
                         <i class="fas fa-user-plus"></i> Join Now
                     </a>
                 <?php endif; ?>
@@ -77,7 +77,7 @@ try {
                     <div class="card-body">
                         <div class="list-group">
                             <?php foreach ($recentThreats as $threat): ?>
-                                <a href="/threats/details.php?id=<?= $threat['threat_id'] ?>" 
+                                <a href="<?= BASE_URL ?>threats/details.php?id=<?= $threat['threat_id'] ?>"
                                    class="list-group-item list-group-item-action">
                                     <div class="d-flex w-100 justify-content-between">
                                         <h5 class="mb-1"><?= htmlspecialchars($threat['entity']) ?></h5>
@@ -90,7 +90,7 @@ try {
                         </div>
                     </div>
                     <div class="card-footer text-center">
-                        <a href="/search.php" class="btn btn-primary">View All Threats</a>
+                        <a href="<?= BASE_URL ?>search.php" class="btn btn-primary">View All Threats</a>
                     </div>
                 </div>
             </div>

--- a/login.php
+++ b/login.php
@@ -3,12 +3,12 @@ require_once __DIR__ . '/includes/config.php';
 require_once __DIR__ . '/includes/auth.php';
 
 if (Auth::isLoggedIn()) {
-    header("Location: /dashboard.php");
+    header("Location: " . BASE_URL . "dashboard.php");
     exit;
 }
 
 $errors = [];
-$redirect = $_GET['redirect'] ?? '/dashboard.php';
+$redirect = $_GET['redirect'] ?? BASE_URL . 'dashboard.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     try {
@@ -75,7 +75,7 @@ require_once __DIR__ . '/includes/header.php';
                     <label for="password">Password</label>
                     <input type="password" class="form-control" id="password" name="password" required>
                     <small class="form-text text-right">
-                        <a href="/password-reset.php">Forgot password?</a>
+                        <a href="<?= BASE_URL ?>password-reset.php">Forgot password?</a>
                     </small>
                 </div>
                 
@@ -88,10 +88,10 @@ require_once __DIR__ . '/includes/header.php';
                 
                 <div class="social-login mt-4">
                     <p class="text-center text-muted">Or sign in with</p>
-                    <a href="/auth/google" class="social-btn google">
+                    <a href="<?= BASE_URL ?>auth/google" class="social-btn google">
                         <i class="fab fa-google"></i> Google
                     </a>
-                    <a href="/auth/facebook" class="social-btn facebook">
+                    <a href="<?= BASE_URL ?>auth/facebook" class="social-btn facebook">
                         <i class="fab fa-facebook-f"></i> Facebook
                     </a>
                 </div>
@@ -99,7 +99,7 @@ require_once __DIR__ . '/includes/header.php';
         </div>
         
         <div class="auth-footer">
-            Don't have an account? <a href="/register.php">Sign up</a>
+            Don't have an account? <a href="<?= BASE_URL ?>register.php">Sign up</a>
         </div>
     </div>
 </div>

--- a/verify.php
+++ b/verify.php
@@ -3,12 +3,12 @@ require_once __DIR__ . '/includes/config.php';
 require_once __DIR__ . '/includes/auth.php';
 
 if (Auth::isLoggedIn() && Auth::isVerified()) {
-    header("Location: /dashboard.php");
+    header("Location: " . BASE_URL . "dashboard.php");
     exit;
 }
 
 if (!Auth::isLoggedIn()) {
-    header("Location: /login.php?redirect=/verify.php");
+    header("Location: " . BASE_URL . "login.php?redirect=" . BASE_URL . "verify.php");
     exit;
 }
 
@@ -69,7 +69,7 @@ require_once __DIR__ . '/includes/header.php';
                 <div class="alert alert-success">
                     Your account has been verified successfully!
                 </div>
-                <a href="/dashboard.php" class="btn btn-primary btn-block">Continue to Dashboard</a>
+                <a href="<?= BASE_URL ?>dashboard.php" class="btn btn-primary btn-block">Continue to Dashboard</a>
             <?php else: ?>
                 <?php if (!empty($errors)): ?>
                     <div class="alert alert-danger">


### PR DESCRIPTION
The application was using root-relative URLs (e.g., `/style.css`) for all assets and internal links. This caused problems when the application was deployed in a subdirectory instead of the web root, as all links would point to the wrong location.

I resolved the issue by:
1.  Introducing a dynamic `BASE_URL` constant in `includes/config.php`. This constant automatically determines the full URL to the application's root, whether it's in the main directory or a subdirectory.
2.  Replacing all hardcoded root-relative links in the application with the new `BASE_URL` constant. This includes links for CSS, JavaScript, images, and all internal page navigation.

These changes ensure that all links and assets will now resolve correctly regardless of the deployment environment.