### PR TITLE
feat: Enhance admin threat management capabilities

### DIFF
--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -38,6 +38,33 @@ const getAdminStats = asyncHandler(async (req, res) => {
     });
 });
 
+const verifyThreat = asyncHandler(async (req, res) => {
+    const report = await Report.findById(req.params.id);
+
+    if (report) {
+        report.verificationStatus = 'verified';
+        const updatedReport = await report.save();
+        res.json(updatedReport);
+    } else {
+        res.status(404).json({ message: 'Report not found' });
+    }
+});
+
+const setThreatVisibility = asyncHandler(async (req, res) => {
+    const { isPublic } = req.body;
+    const report = await Report.findById(req.params.id);
+
+    if (report) {
+        report.isPublic = isPublic;
+        const updatedReport = await report.save();
+        res.json(updatedReport);
+    } else {
+        res.status(404).json({ message: 'Report not found' });
+    }
+});
+
 module.exports = {
-    getAdminStats
+    getAdminStats,
+    verifyThreat,
+    setThreatVisibility
 };

--- a/models/report.js
+++ b/models/report.js
@@ -23,7 +23,8 @@ const reportSchema = new mongoose.Schema({
         aliases: [{ type: String }]
     }],
     riskLevel: { type: String, enum: ['low', 'medium', 'high'], default: 'low' }, // Risk classification
-    isPublic: { type: Boolean, default: false } // Public visibility
+    isPublic: { type: Boolean, default: false }, // Public visibility
+    verificationStatus: { type: String, enum: ['unverified', 'verified'], default: 'unverified' }
 }, {
     timestamps: true,
     toJSON: { virtuals: true },
@@ -35,7 +36,7 @@ reportSchema.virtual('reviewCount').get(function() {
     return this.reviews.length;
 });
 
-// Middleware to update riskLevel and isPublic before saving
+// Middleware to update riskLevel, isPublic and verificationStatus before saving
 reportSchema.pre('save', function (next) {
     const reviewCount = this.reviews.length;
     if (reviewCount >= 100) {
@@ -48,6 +49,12 @@ reportSchema.pre('save', function (next) {
 
     // Make the instrument public if it has 50 or more reports
     this.isPublic = reviewCount >= 50;
+
+    // Automatically verify the instrument if it has 200 or more reports
+    if (reviewCount >= 200) {
+        this.verificationStatus = 'verified';
+    }
+
     next();
 });
 

--- a/routes/adminRoutes.js
+++ b/routes/adminRoutes.js
@@ -1,9 +1,15 @@
 const express = require('express');
 const router = express.Router();
-const { getAdminStats } = require('../controllers/adminController');
+const { getAdminStats, verifyThreat, setThreatVisibility } = require('../controllers/adminController');
 const { protect, adminOnly } = require('../middleware/authMiddleware');
 
 router.route('/stats')
     .get(protect, adminOnly, getAdminStats);
+
+router.route('/reports/:id/verify')
+    .put(protect, adminOnly, verifyThreat);
+
+router.route('/reports/:id/set-visibility')
+    .put(protect, adminOnly, setThreatVisibility);
 
 module.exports = router;

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -1,0 +1,89 @@
+const request = require('supertest');
+const express = require('express');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const adminRoutes = require('../routes/adminRoutes');
+const authMiddleware = require('../middleware/authMiddleware');
+const User = require('../models/user');
+const Report = require('../models/report');
+
+// Mock the auth middleware
+jest.mock('../middleware/authMiddleware', () => ({
+    protect: jest.fn((req, res, next) => {
+        next();
+    }),
+    adminOnly: jest.fn((req, res, next) => {
+        if (req.user && req.user.role === 'admin') {
+            next();
+        } else {
+            res.status(403).json({ message: 'Forbidden' });
+        }
+    })
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/admin', adminRoutes);
+
+describe('Admin Routes', () => {
+    let mongoServer;
+
+    beforeAll(async () => {
+        mongoServer = await MongoMemoryServer.create();
+        const uri = mongoServer.getUri();
+        await mongoose.connect(uri);
+    });
+
+    afterAll(async () => {
+        await mongoose.disconnect();
+        await mongoServer.stop();
+    });
+
+    afterEach(async () => {
+        await Report.deleteMany();
+        await User.deleteMany();
+    });
+
+    describe('PUT /api/admin/reports/:id/verify', () => {
+        it('should verify a report', async () => {
+            const admin = new User({ name: 'Admin', email: 'admin@test.com', password: 'password', role: 'admin' });
+            await admin.save();
+
+            const report = new Report({ instrument: 'test.com', type: 'website', reviews: [{ user: admin._id, description: 'test' }] });
+            await report.save();
+
+            authMiddleware.protect.mockImplementation((req, res, next) => {
+                req.user = admin;
+                next();
+            });
+
+            const res = await request(app)
+                .put(`/api/admin/reports/${report._id}/verify`);
+
+            expect(res.statusCode).toEqual(200);
+            expect(res.body.verificationStatus).toBe('verified');
+        });
+    });
+
+    describe('PUT /api/admin/reports/:id/set-visibility', () => {
+        it('should set the visibility of a report', async () => {
+            const admin = new User({ name: 'Admin', email: 'admin@test.com', password: 'password', role: 'admin' });
+            await admin.save();
+
+            const report = new Report({ instrument: 'test.com', type: 'website', isPublic: true, reviews: [{ user: admin._id, description: 'test' }] });
+            await report.save();
+
+            authMiddleware.protect.mockImplementation((req, res, next) => {
+                req.user = admin;
+                next();
+            });
+
+            const res = await request(app)
+                .put(`/api/admin/reports/${report._id}/set-visibility`)
+                .send({ isPublic: false });
+
+            expect(res.statusCode).toEqual(200);
+            expect(res.body.isPublic).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
This commit introduces new features for administrators to manage threats more effectively.

- **Verified vs. Unverified Threats:**
  - Added a `verificationStatus` to the `Report` model to distinguish between `unverified` and `verified` threats.
  - Threats are now automatically marked as `verified` upon reaching 200 reports.
  - A new API endpoint (`PUT /api/admin/reports/:id/verify`) allows admins to manually mark a threat as verified.

- **Threat Visibility Control:**
  - A new API endpoint (`PUT /api/admin/reports/:id/set-visibility`) allows admins to make a threat private by setting its `isPublic` status to `false`.

- **Testing:**
  - Added new tests for the admin-specific routes to ensure the new functionality is working as expected.