### PR TITLE
feat: update report email with conditional content

### DIFF
--- a/controllers/reportController.js
+++ b/controllers/reportController.js
@@ -43,8 +43,9 @@ const reportInstrument = async (req, res) => {
         }
 
         let report = await Report.findOne({ instrument, type });
+        const isNewThreat = !report;
 
-        if (!report) {
+        if (isNewThreat) {
             report = new Report({ instrument, type, reviews: [] });
         }
 
@@ -64,7 +65,7 @@ const reportInstrument = async (req, res) => {
         await report.save();
 
         // Notify user
-        await reportMail(req.user, instrument);
+        await reportMail(req.user, instrument, isNewThreat);
 
         // If the report just became public, send real-time alerts
         if (report.isPublic && !wasPublic) {

--- a/utils/emailServices.js
+++ b/utils/emailServices.js
@@ -166,12 +166,21 @@ const emailVerified = async (user) => {
 };
 
 // Notify user when they successfully report an instrument
-const reportMail = async (user, instrument) => {
+const reportMail = async (user, instrument, isNewThreat) => {
     const subject = 'Your Report Has Been Successfully Submitted';
+
+    let message;
+    if (isNewThreat) {
+        message = `<p>This appears to be a new threat. We encourage you to have other victims report it to increase its visibility.</p>`;
+    } else {
+        message = `<p>Thank you for being part of the people keeping the community safe. This threat has been reported by other members and is already in our database.</p>`;
+    }
+
     const content = `
         <p>Dear ${user.name},</p>
         <p>Your report for the Threat <strong>${instrument}</strong> has been successfully submitted.</p>
-        <p>Thank you for helping to keep the community safe!</p>
+        ${message}
+        <p>Please be aware that making a false report out of malicious intent is illegal and may be a litigable offense.</p>
     `;
     const html = baseEmailTemplate('Report Submitted Successfully', content);
     await sendEmail(user.email, subject, html);


### PR DESCRIPTION
This commit updates the email sent to users after they report a threat.

The email content is now conditional based on whether the threat is new or already exists in the database.

- If the threat is new, the user is encouraged to have others report it to increase its visibility.
- If the threat already exists, the user is thanked for helping to confirm a known threat.
- A legal disclaimer about the consequences of malicious reporting has been added to all report confirmation emails.