### PR TITLE
feat: Update instrument types and add autocomplete search

### DIFF
--- a/controllers/reportController.js
+++ b/controllers/reportController.js
@@ -15,14 +15,26 @@ const {
  * @returns {boolean} - True if the instrument is valid, false otherwise
  */
 const validateInstrument = (instrument, type) => {
-    if (type === 'email') {
-        return validator.isEmail(instrument);
-    } else if (type === 'phone') {
-        return validator.isMobilePhone(instrument, 'any', { strictMode: false });
-    } else if (type === 'website') {
-        return validator.isURL(instrument, { protocols: ['http', 'https'], require_protocol: true });
+    switch (type) {
+        case 'email':
+        case 'Scam Email':
+        case 'Scam/Fraudulent Email':
+            return validator.isEmail(instrument);
+        case 'phone':
+        case 'Fraudulent Phone Number':
+            return validator.isMobilePhone(instrument, 'any', { strictMode: false });
+        case 'website':
+        case 'Fraudulent Website':
+        case 'Phishing Website':
+            return validator.isURL(instrument, { protocols: ['http', 'https'], require_protocol: true });
+        case 'business':
+        case 'Fraudulent Business':
+        case 'Fake Tech Support':
+        case 'Malware Distribution':
+            return typeof instrument === 'string' && instrument.length > 0;
+        default:
+            return false; // Disallow unknown types
     }
-    return false;
 };
 
 /**
@@ -145,8 +157,26 @@ const fetchAllReportsAdmin = async (req, res) => {
     }
 };
 
+/**
+ * @desc    Get all instrument types
+ * @route   GET /api/reports/types
+ * @access  Public
+ */
+const getInstrumentTypes = (req, res) => {
+    try {
+        const instrumentTypes = Report.schema.path('type').enumValues;
+        res.status(200).json({
+            success: true,
+            data: instrumentTypes,
+        });
+    } catch (error) {
+        res.status(500).json({ success: false, message: 'Server error', error });
+    }
+};
+
 module.exports = { 
     reportInstrument,
     fetchAllReports,
-    fetchAllReportsAdmin
+    fetchAllReportsAdmin,
+    getInstrumentTypes
 };

--- a/controllers/searchController.js
+++ b/controllers/searchController.js
@@ -13,7 +13,7 @@ const searchInstrument = async (req, res) => {
 
     try {
         // Validate the type
-        const validTypes = ['phone', 'email', 'business', 'website', 'Fake Tech Support', 'Fraudulent Phone Number', 'Malware Distribution', 'Phishing Website', 'Scam Email'];
+        const validTypes = Report.schema.path('type').enumValues;
         if (!validTypes.includes(type)) {
             return res.status(400).json({ message: 'Invalid instrument type.' });
         }
@@ -62,4 +62,27 @@ const searchInstrument = async (req, res) => {
     }
 };
 
-module.exports = { searchInstrument };
+/**
+ * @desc    Autocomplete search for instruments
+ * @route   GET /api/search/autocomplete
+ * @access  Public
+ */
+const autocompleteSearch = async (req, res) => {
+    try {
+        const { q } = req.query;
+        if (!q) {
+            return res.status(400).json({ message: 'Query parameter "q" is required.' });
+        }
+
+        const reports = await Report.find({
+            instrument: { $regex: `^${q}`, $options: 'i' },
+            isPublic: true
+        }).limit(10);
+
+        res.status(200).json(reports);
+    } catch (error) {
+        res.status(500).json({ message: 'Server error', error });
+    }
+};
+
+module.exports = { searchInstrument, autocompleteSearch };

--- a/models/report.js
+++ b/models/report.js
@@ -13,7 +13,10 @@ const reportSchema = new mongoose.Schema({
             'Fraudulent Phone Number',
             'Malware Distribution',
             'Phishing Website',
-            'Scam Email'
+            'Scam Email',
+            'Fraudulent Business',
+            'Fraudulent Website',
+            'Scam/Fraudulent Email'
         ],
         required: true
     },

--- a/routes/reportRoutes.js
+++ b/routes/reportRoutes.js
@@ -1,12 +1,53 @@
 const express = require('express');
-const { 
+const {
     reportInstrument,
     fetchAllReports,
-    fetchAllReportsAdmin
+    fetchAllReportsAdmin,
+    getInstrumentTypes
 } = require('../controllers/reportController');
 const { protect, adminOnly } = require('../middleware/authMiddleware');
 
 const router = express.Router();
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     InstrumentType:
+ *       type: string
+ *       enum:
+ *         - phone
+ *         - email
+ *         - business
+ *         - website
+ *         - Fake Tech Support
+ *         - Fraudulent Phone Number
+ *         - Malware Distribution
+ *         - Phishing Website
+ *         - Scam Email
+ *         - Fraudulent Business
+ *         - Fraudulent Website
+ *         - Scam/Fraudulent Email
+ */
+
+/**
+ * @swagger
+ * /api/reports/types:
+ *   get:
+ *     summary: Get all instrument types
+ *     description: Retrieves a list of all possible instrument types.
+ *     responses:
+ *       200:
+ *         description: A list of instrument types.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/InstrumentType'
+ */
+router.route('/types')
+    .get(getInstrumentTypes);
 
 /**
  * @swagger
@@ -30,8 +71,7 @@ const router = express.Router();
  *               instrument:
  *                 type: string
  *               type:
- *                 type: string
- *                 enum: [email, phone, website]
+ *                 $ref: '#/components/schemas/InstrumentType'
  *               description:
  *                 type: string
  *               aliases:
@@ -62,8 +102,7 @@ const router = express.Router();
  *       - in: query
  *         name: type
  *         schema:
- *           type: string
- *           enum: [email, phone, website]
+ *           $ref: '#/components/schemas/InstrumentType'
  *         description: The type of reports to retrieve.
  *     responses:
  *       200:
@@ -71,7 +110,7 @@ const router = express.Router();
  */
 router.route('/')
     .post(protect, reportInstrument) // For reporting an instrument
-    .get(fetchAllReports)// For fetching all reports
+    .get(fetchAllReports); // For fetching all reports
 
 /**
  * @swagger
@@ -85,8 +124,7 @@ router.route('/')
  *       - in: query
  *         name: type
  *         schema:
- *           type: string
- *           enum: [email, phone, website]
+ *           $ref: '#/components/schemas/InstrumentType'
  *         description: The type of reports to retrieve.
  *       - in: query
  *         name: instrument

--- a/routes/searchRoutes.js
+++ b/routes/searchRoutes.js
@@ -1,10 +1,32 @@
 
 // routes/searchRoutes.js
 const express = require('express');
-const { searchInstrument } = require('../controllers/searchController');
+const { searchInstrument, autocompleteSearch } = require('../controllers/searchController');
 const { optionalAuth } = require('../middleware/authMiddleware'); // Optional authentication middleware
 
 const router = express.Router();
+
+/**
+ * @swagger
+ * /api/search/autocomplete:
+ *   get:
+ *     summary: Autocomplete search for an instrument
+ *     description: Searches for instruments matching a partial query string.
+ *     parameters:
+ *       - in: query
+ *         name: q
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: The partial instrument string to search for.
+ *     responses:
+ *       200:
+ *         description: A list of matching instruments.
+ *       400:
+ *         description: Missing query parameter.
+ */
+router.route('/autocomplete')
+    .get(autocompleteSearch);
 
 /**
  * @swagger
@@ -25,8 +47,7 @@ const router = express.Router();
  *               instrument:
  *                 type: string
  *               type:
- *                 type: string
- *                 enum: [phone, email, business, website, 'Fake Tech Support', 'Fraudulent Phone Number', 'Malware Distribution', 'Phishing Website', 'Scam Email']
+ *                 $ref: '#/components/schemas/InstrumentType'
  *     responses:
  *       200:
  *         description: The search results.


### PR DESCRIPTION
This commit addresses three user requests:

1.  Updates the list of instrument types in the `report` model to include 'Fraudulent Business', 'Fraudulent Website', and 'Scam/Fraudulent Email'. The validation logic is also updated to handle these new types.

2.  Adds a new API endpoint `GET /api/reports/types` that allows the frontend to dynamically fetch the list of available instrument types.

3.  Implements an autocomplete search feature with a new API endpoint `GET /api/search/autocomplete?q=<query>` that performs a partial, case-insensitive search for public instruments.