### PR TITLE
feat: Update instrument types and add autocomplete search

### DIFF
--- a/controllers/reportController.js
+++ b/controllers/reportController.js
@@ -16,21 +16,13 @@ const {
  */
 const validateInstrument = (instrument, type) => {
     switch (type) {
-        case 'email':
-        case 'Scam Email':
         case 'Scam/Fraudulent Email':
             return validator.isEmail(instrument);
-        case 'phone':
         case 'Fraudulent Phone Number':
             return validator.isMobilePhone(instrument, 'any', { strictMode: false });
-        case 'website':
         case 'Fraudulent Website':
-        case 'Phishing Website':
             return validator.isURL(instrument, { protocols: ['http', 'https'], require_protocol: true });
-        case 'business':
         case 'Fraudulent Business':
-        case 'Fake Tech Support':
-        case 'Malware Distribution':
             return typeof instrument === 'string' && instrument.length > 0;
         default:
             return false; // Disallow unknown types

--- a/models/report.js
+++ b/models/report.js
@@ -5,18 +5,10 @@ const reportSchema = new mongoose.Schema({
     type: {
         type: String,
         enum: [
-            'phone',
-            'email',
-            'business',
-            'website',
-            'Fake Tech Support',
             'Fraudulent Phone Number',
-            'Malware Distribution',
-            'Phishing Website',
-            'Scam Email',
-            'Fraudulent Business',
             'Fraudulent Website',
-            'Scam/Fraudulent Email'
+            'Scam/Fraudulent Email',
+            'Fraudulent Business'
         ],
         required: true
     },

--- a/routes/reportRoutes.js
+++ b/routes/reportRoutes.js
@@ -16,18 +16,10 @@ const router = express.Router();
  *     InstrumentType:
  *       type: string
  *       enum:
- *         - phone
- *         - email
- *         - business
- *         - website
- *         - Fake Tech Support
  *         - Fraudulent Phone Number
- *         - Malware Distribution
- *         - Phishing Website
- *         - Scam Email
- *         - Fraudulent Business
  *         - Fraudulent Website
  *         - Scam/Fraudulent Email
+ *         - Fraudulent Business
  */
 
 /**

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -49,7 +49,7 @@ describe('Admin Routes', () => {
             const admin = new User({ name: 'Admin', email: 'admin@test.com', password: 'password', role: 'admin' });
             await admin.save();
 
-            const report = new Report({ instrument: 'test.com', type: 'website', reviews: [{ user: admin._id, description: 'test' }] });
+            const report = new Report({ instrument: 'test.com', type: 'Fraudulent Website', reviews: [{ user: admin._id, description: 'test' }] });
             await report.save();
 
             authMiddleware.protect.mockImplementation((req, res, next) => {
@@ -70,7 +70,7 @@ describe('Admin Routes', () => {
             const admin = new User({ name: 'Admin', email: 'admin@test.com', password: 'password', role: 'admin' });
             await admin.save();
 
-            const report = new Report({ instrument: 'test.com', type: 'website', isPublic: true, reviews: [{ user: admin._id, description: 'test' }] });
+            const report = new Report({ instrument: 'test.com', type: 'Fraudulent Website', isPublic: true, reviews: [{ user: admin._id, description: 'test' }] });
             await report.save();
 
             authMiddleware.protect.mockImplementation((req, res, next) => {


### PR DESCRIPTION
This commit addresses three user requests, with corrections based on user feedback:

1.  Updates the list of instrument types in the `report` model to a specific list of four types as requested by the user: 'Fraudulent Phone Number', 'Fraudulent Website', 'Scam/Fraudulent Email', and 'Fraudulent Business'. The validation logic is also updated to handle only these types.

2.  Adds a new API endpoint `GET /api/reports/types` that allows the frontend to dynamically fetch the list of available instrument types.

3.  Implements an autocomplete search feature with a new API endpoint `GET /api/search/autocomplete?q=<query>` that performs a partial, case-insensitive search for public instruments.