### PR TITLE
feat: Add admin threat visibility control and public stats route

### DIFF
--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -51,11 +51,11 @@ const verifyThreat = asyncHandler(async (req, res) => {
 });
 
 const setThreatVisibility = asyncHandler(async (req, res) => {
-    const { isPublic } = req.body;
+    const { forcePublic } = req.body;
     const report = await Report.findById(req.params.id);
 
     if (report) {
-        report.isPublic = isPublic;
+        report.forcePublic = forcePublic;
         const updatedReport = await report.save();
         res.json(updatedReport);
     } else {

--- a/controllers/reportController.js
+++ b/controllers/reportController.js
@@ -166,9 +166,24 @@ const getInstrumentTypes = (req, res) => {
     }
 };
 
+/**
+ * @desc    Get total number of public threats
+ * @route   GET /api/reports/stats/total
+ * @access  Public
+ */
+const getTotalThreats = async (req, res) => {
+    try {
+        const total = await Report.countDocuments({ isPublic: true });
+        res.status(200).json({ success: true, total });
+    } catch (error) {
+        res.status(500).json({ success: false, message: 'Server error', error });
+    }
+};
+
 module.exports = { 
     reportInstrument,
     fetchAllReports,
     fetchAllReportsAdmin,
-    getInstrumentTypes
+    getInstrumentTypes,
+    getTotalThreats
 };

--- a/models/report.js
+++ b/models/report.js
@@ -19,6 +19,7 @@ const reportSchema = new mongoose.Schema({
     }],
     riskLevel: { type: String, enum: ['low', 'medium', 'high'], default: 'low' }, // Risk classification
     isPublic: { type: Boolean, default: false }, // Public visibility
+    forcePublic: { type: Boolean, default: false }, // Admin override for public visibility
     verificationStatus: { type: String, enum: ['unverified', 'verified'], default: 'unverified' }
 }, {
     timestamps: true,
@@ -42,8 +43,8 @@ reportSchema.pre('save', function (next) {
         this.riskLevel = 'low';
     }
 
-    // Make the instrument public if it has 50 or more reports
-    this.isPublic = reviewCount >= 50;
+    // Make the instrument public if it has 50 or more reports or if forced by an admin
+    this.isPublic = reviewCount >= 50 || this.forcePublic;
 
     // Automatically verify the instrument if it has 200 or more reports
     if (reviewCount >= 200) {

--- a/routes/adminRoutes.js
+++ b/routes/adminRoutes.js
@@ -48,10 +48,10 @@ router.route('/reports/:id/verify')
 
 /**
  * @swagger
- * /api/admin/reports/{id}/set-visibility:
- *   put:
- *     summary: Set threat visibility
- *     description: Sets the visibility of a threat report.
+ * /api/admin/reports/{id}/visibility:
+ *   patch:
+ *     summary: Set threat visibility (Admin)
+ *     description: Sets the public visibility of a threat report, overriding the default logic.
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -68,19 +68,19 @@ router.route('/reports/:id/verify')
  *           schema:
  *             type: object
  *             required:
- *               - isPublic
+ *               - forcePublic
  *             properties:
- *               isPublic:
+ *               forcePublic:
  *                 type: boolean
  *     responses:
  *       200:
- *         description: Report visibility set successfully.
+ *         description: Report visibility updated successfully.
  *       401:
  *         description: Unauthorized.
  *       404:
  *         description: Report not found.
  */
-router.route('/reports/:id/set-visibility')
-    .put(protect, adminOnly, setThreatVisibility);
+router.route('/reports/:id/visibility')
+    .patch(protect, adminOnly, setThreatVisibility);
 
 module.exports = router;

--- a/routes/reportRoutes.js
+++ b/routes/reportRoutes.js
@@ -3,7 +3,8 @@ const {
     reportInstrument,
     fetchAllReports,
     fetchAllReportsAdmin,
-    getInstrumentTypes
+    getInstrumentTypes,
+    getTotalThreats
 } = require('../controllers/reportController');
 const { protect, adminOnly } = require('../middleware/authMiddleware');
 
@@ -131,5 +132,25 @@ router.route('/')
  */
 router.route('/admin')
     .get(protect, adminOnly, fetchAllReportsAdmin); // For fetching all reports
+
+/**
+ * @swagger
+ * /api/reports/stats/total:
+ *   get:
+ *     summary: Get total number of public threats
+ *     description: Retrieves the total number of reports that are marked as public.
+ *     responses:
+ *       200:
+ *         description: Total number of public threats retrieved successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 total:
+ *                   type: integer
+ */
+router.route('/stats/total')
+    .get(getTotalThreats);
 
 module.exports = router;

--- a/tests/admin.test.js
+++ b/tests/admin.test.js
@@ -65,7 +65,7 @@ describe('Admin Routes', () => {
         });
     });
 
-    describe('PUT /api/admin/reports/:id/set-visibility', () => {
+    describe('PATCH /api/admin/reports/:id/visibility', () => {
         it('should set the visibility of a report', async () => {
             const admin = new User({ name: 'Admin', email: 'admin@test.com', password: 'password', role: 'admin' });
             await admin.save();
@@ -79,10 +79,11 @@ describe('Admin Routes', () => {
             });
 
             const res = await request(app)
-                .put(`/api/admin/reports/${report._id}/set-visibility`)
-                .send({ isPublic: false });
+                .patch(`/api/admin/reports/${report._id}/visibility`)
+                .send({ forcePublic: false });
 
             expect(res.statusCode).toEqual(200);
+            expect(res.body.forcePublic).toBe(false);
             expect(res.body.isPublic).toBe(false);
         });
     });


### PR DESCRIPTION
This commit introduces two new features:

1.  A new public route, GET /api/reports/stats/total, which returns the total number of publicly visible threat reports.
2.  An admin-only feature to control the visibility of threat reports. This is exposed via the PATCH /api/admin/reports/:id/visibility route, which allows an admin to set the `forcePublic` flag on a report, overriding the default visibility logic.

The `Report` model has been updated to include the `forcePublic` field, and the pre-save hook has been modified to account for this new field when determining the `isPublic` status.

All related routes, controllers, and tests have been updated to reflect these changes.