### PR TITLE
feat: Update stats route to return total and verified threats

### DIFF
--- a/controllers/reportController.js
+++ b/controllers/reportController.js
@@ -167,14 +167,21 @@ const getInstrumentTypes = (req, res) => {
 };
 
 /**
- * @desc    Get total number of public threats
+ * @desc    Get threat statistics
  * @route   GET /api/reports/stats/total
  * @access  Public
  */
 const getTotalThreats = async (req, res) => {
     try {
-        const total = await Report.countDocuments({ isPublic: true });
-        res.status(200).json({ success: true, total });
+        const totalThreats = await Report.countDocuments();
+        const verifiedThreats = await Report.countDocuments({ verificationStatus: 'verified' });
+        res.status(200).json({
+            success: true,
+            stats: {
+                totalThreats,
+                verifiedThreats
+            }
+        });
     } catch (error) {
         res.status(500).json({ success: false, message: 'Server error', error });
     }

--- a/routes/reportRoutes.js
+++ b/routes/reportRoutes.js
@@ -137,18 +137,25 @@ router.route('/admin')
  * @swagger
  * /api/reports/stats/total:
  *   get:
- *     summary: Get total number of public threats
- *     description: Retrieves the total number of reports that are marked as public.
+ *     summary: Get threat statistics
+ *     description: Retrieves the total number of all reported threats and the total number of verified threats.
  *     responses:
  *       200:
- *         description: Total number of public threats retrieved successfully.
+ *         description: Threat statistics retrieved successfully.
  *         content:
  *           application/json:
  *             schema:
  *               type: object
  *               properties:
- *                 total:
- *                   type: integer
+ *                 success:
+ *                   type: boolean
+ *                 stats:
+ *                   type: object
+ *                   properties:
+ *                     totalThreats:
+ *                       type: integer
+ *                     verifiedThreats:
+ *                       type: integer
  */
 router.route('/stats/total')
     .get(getTotalThreats);

--- a/tests/report.test.js
+++ b/tests/report.test.js
@@ -1,0 +1,66 @@
+const request = require('supertest');
+const express = require('express');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const reportRoutes = require('../routes/reportRoutes');
+const Report = require('../models/report');
+const User = require('../models/user');
+
+const app = express();
+app.use(express.json());
+app.use('/api/reports', reportRoutes);
+
+// Mock auth middleware for protected routes if any are added to this test file
+jest.mock('../middleware/authMiddleware', () => ({
+    protect: jest.fn((req, res, next) => {
+        // a mock user can be attached to req if needed by any of the routes
+        next();
+    }),
+    adminOnly: jest.fn((req, res, next) => {
+        next();
+    })
+}));
+
+
+describe('Report Routes', () => {
+    let mongoServer;
+
+    beforeAll(async () => {
+        mongoServer = await MongoMemoryServer.create();
+        const uri = mongoServer.getUri();
+        await mongoose.connect(uri);
+    });
+
+    afterAll(async () => {
+        await mongoose.disconnect();
+        await mongoServer.stop();
+    });
+
+    afterEach(async () => {
+        await Report.deleteMany();
+        await User.deleteMany();
+    });
+
+    describe('GET /api/reports/stats/total', () => {
+        it('should return the total number of all threats and verified threats', async () => {
+            const user = new User({ name: 'Test User', email: 'test@test.com', password: 'password' });
+            await user.save();
+
+            await Report.create([
+                { instrument: 'test1.com', type: 'Fraudulent Website', reviews: [{ user: user._id, description: 'test' }], verificationStatus: 'verified' },
+                { instrument: 'test2.com', type: 'Fraudulent Website', reviews: [{ user: user._id, description: 'test' }], verificationStatus: 'verified' },
+                { instrument: 'test3.com', type: 'Fraudulent Website', reviews: [{ user: user._id, description: 'test' }], verificationStatus: 'unverified' },
+                { instrument: 'test4.com', type: 'Fraudulent Website', reviews: [{ user: user._id, description: 'test' }], verificationStatus: 'unverified' },
+                { instrument: 'test5.com', type: 'Fraudulent Website', reviews: [{ user: user._id, description: 'test' }], verificationStatus: 'verified' },
+            ]);
+
+            const res = await request(app)
+                .get('/api/reports/stats/total');
+
+            expect(res.statusCode).toEqual(200);
+            expect(res.body.success).toBe(true);
+            expect(res.body.stats.totalThreats).toBe(5);
+            expect(res.body.stats.verifiedThreats).toBe(3);
+        });
+    });
+});


### PR DESCRIPTION
This commit modifies the `GET /api/reports/stats/total` route to return both the total number of all reported threats and the total number of verified threats.

The `getTotalThreats` controller in `controllers/reportController.js` has been updated to fetch these two new values, and the response format has been adjusted accordingly.

The Swagger documentation for this route in `routes/reportRoutes.js` has also been updated to reflect the new response format.

A new test file, `tests/report.test.js`, has been created with a test case to verify that the new statistics are returned correctly.