### PR TITLE
Fix: Use deleteOne instead of remove for deleting articles

### DIFF
--- a/controllers/articleController.js
+++ b/controllers/articleController.js
@@ -66,7 +66,7 @@ const deleteArticle = asyncHandler(async (req, res) => {
     const article = await Article.findById(req.params.id);
 
     if (article) {
-        await article.remove();
+        await Article.deleteOne({ _id: article._id });
         res.json({ message: 'Article removed' });
     } else {
         res.status(404).json({ message: 'Article not found' });


### PR DESCRIPTION
The `article.remove()` method is deprecated in recent versions of Mongoose, which was causing a 500 server error when a DELETE request was made to `/api/articles/:id`.

This commit replaces the deprecated `article.remove()` with `Article.deleteOne({ _id: article._id })` to align with the current Mongoose API and resolve the error. The surrounding logic remains the same: the controller first finds the article to ensure it exists before attempting to delete it.