### PR TITLE
Fix CORS configuration to allow PATCH requests

### DIFF
--- a/routes/adminRoutes.js
+++ b/routes/adminRoutes.js
@@ -81,6 +81,6 @@ router.route('/reports/:id/verify')
  *         description: Report not found.
  */
 router.route('/reports/:id/visibility')
-    .put(protect, adminOnly, setThreatVisibility);
+    .patch(protect, adminOnly, setThreatVisibility);
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ app.use(cors({
       callback(new Error("Not allowed by CORS"));
     }
   },
-  methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+  methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
   allowedHeaders: ["Content-Type", "Authorization"],
   credentials: true
 }));


### PR DESCRIPTION
The server's CORS configuration was not allowing PATCH requests, which was causing errors when the frontend tried to update a resource using the PATCH method. This was causing a downstream bug where a developer had tried to work around this by changing the method to PUT, but this was causing other issues.

This commit adds 'PATCH' to the list of allowed methods in the CORS configuration in `server.js`.

It also reverts the `/api/admin/reports/:id/visibility` route back to using the `PATCH` method as intended and documented in the swagger comments.