### PR TITLE
feat: Add edit and delete functionality for reports

### DIFF
--- a/models/report.js
+++ b/models/report.js
@@ -19,6 +19,7 @@ const reportSchema = new mongoose.Schema({
     }],
     riskLevel: { type: String, enum: ['low', 'medium', 'high'], default: 'low' }, // Risk classification
     isPublic: { type: Boolean, default: false }, // Public visibility
+    createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
     forcePublic: { type: Boolean, default: false }, // Admin override for public visibility
     verificationStatus: { type: String, enum: ['unverified', 'verified'], default: 'unverified' }
 }, {

--- a/routes/reportRoutes.js
+++ b/routes/reportRoutes.js
@@ -4,7 +4,10 @@ const {
     fetchAllReports,
     fetchAllReportsAdmin,
     getInstrumentTypes,
-    getTotalThreats
+    getTotalThreats,
+    updateReport,
+    adminUpdateReport,
+    adminDeleteReport
 } = require('../controllers/reportController');
 const { protect, adminOnly } = require('../middleware/authMiddleware');
 
@@ -159,5 +162,127 @@ router.route('/admin')
  */
 router.route('/stats/total')
     .get(getTotalThreats);
+
+/**
+ * @swagger
+ * /api/reports/{id}:
+ *   put:
+ *     summary: Update a report
+ *     description: Updates a report. The user can only update their own report within one hour of creation.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the report to update.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               description:
+ *                 type: string
+ *               aliases:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *     responses:
+ *       200:
+ *         description: Report updated successfully.
+ *       400:
+ *         description: Bad request.
+ *       401:
+ *         description: Unauthorized.
+ *       403:
+ *         description: Forbidden.
+ *       404:
+ *         description: Report not found.
+ */
+router.route('/:id')
+    .put(protect, updateReport);
+
+/**
+ * @swagger
+ * /api/reports/admin/{id}:
+ *   put:
+ *     summary: Admin update a report
+ *     description: Updates any report. This is an admin-only endpoint.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the report to update.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               instrument:
+ *                 type: string
+ *               type:
+ *                 $ref: '#/components/schemas/InstrumentType'
+ *               description:
+ *                 type: string
+ *               aliases:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               riskLevel:
+ *                 type: string
+ *                 enum: [low, medium, high]
+ *               isPublic:
+ *                 type: boolean
+ *               forcePublic:
+ *                 type: boolean
+ *               verificationStatus:
+ *                 type: string
+ *                 enum: [unverified, verified]
+ *     responses:
+ *       200:
+ *         description: Report updated successfully.
+ *       400:
+ *         description: Bad request.
+ *       401:
+ *         description: Unauthorized.
+ *       403:
+ *         description: Forbidden.
+ *       404:
+ *         description: Report not found.
+ *   delete:
+ *     summary: Admin delete a report
+ *     description: Deletes any report. This is an admin-only endpoint.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the report to delete.
+ *     responses:
+ *       200:
+ *         description: Report deleted successfully.
+ *       401:
+ *         description: Unauthorized.
+ *       403:
+ *         description: Forbidden.
+ *       404:
+ *         description: Report not found.
+ */
+router.route('/admin/:id')
+    .put(protect, adminOnly, adminUpdateReport)
+    .delete(protect, adminOnly, adminDeleteReport);
 
 module.exports = router;

--- a/tests/report.test.js
+++ b/tests/report.test.js
@@ -10,16 +10,9 @@ const app = express();
 app.use(express.json());
 app.use('/api/reports', reportRoutes);
 
-// Mock auth middleware for protected routes if any are added to this test file
-jest.mock('../middleware/authMiddleware', () => ({
-    protect: jest.fn((req, res, next) => {
-        // a mock user can be attached to req if needed by any of the routes
-        next();
-    }),
-    adminOnly: jest.fn((req, res, next) => {
-        next();
-    })
-}));
+// Mock auth middleware for protected routes
+const mockAuthMiddleware = require('../middleware/authMiddleware');
+jest.mock('../middleware/authMiddleware');
 
 
 describe('Report Routes', () => {
@@ -61,6 +54,158 @@ describe('Report Routes', () => {
             expect(res.body.success).toBe(true);
             expect(res.body.stats.totalThreats).toBe(5);
             expect(res.body.stats.verifiedThreats).toBe(3);
+        });
+    });
+
+    describe('PUT /api/reports/:id', () => {
+        let user, report;
+
+        beforeEach(async () => {
+            user = new User({ name: 'Test User', email: 'test@test.com', password: 'password' });
+            await user.save();
+
+            report = new Report({
+                instrument: 'test.com',
+                type: 'Fraudulent Website',
+                reviews: [{ user: user._id, description: 'Initial review' }],
+                createdBy: user._id
+            });
+            await report.save();
+
+            mockAuthMiddleware.protect.mockImplementation((req, res, next) => {
+                req.user = user;
+                next();
+            });
+        });
+
+        it('should allow a user to update their own review within one hour', async () => {
+            const res = await request(app)
+                .put(`/api/reports/${report._id}`)
+                .send({ description: 'Updated review' });
+
+            expect(res.statusCode).toEqual(200);
+            expect(res.body.message).toBe('Report updated successfully.');
+            const updatedReport = await Report.findById(report._id);
+            expect(updatedReport.reviews[0].description).toBe('Updated review');
+        });
+
+        it('should not allow a user to update their own report after one hour', async () => {
+            report.createdAt = new Date(Date.now() - 3600001);
+            await report.save();
+
+            const res = await request(app)
+                .put(`/api/reports/${report._id}`)
+                .send({ description: 'Updated review' });
+
+            expect(res.statusCode).toEqual(403);
+            expect(res.body.message).toBe('You can only edit a report within one hour of creation.');
+        });
+
+        it('should not allow a user to update another user\'s report', async () => {
+            const anotherUser = new User({ name: 'Another User', email: 'another@test.com', password: 'password' });
+            await anotherUser.save();
+
+            const anotherReport = new Report({
+                instrument: 'another-test.com',
+                type: 'Fraudulent Website',
+                reviews: [{ user: anotherUser._id, description: 'Initial review' }],
+                createdBy: anotherUser._id
+            });
+            await anotherReport.save();
+
+            mockAuthMiddleware.protect.mockImplementation((req, res, next) => {
+                req.user = user;
+                next();
+            });
+
+            const res = await request(app)
+                .put(`/api/reports/${anotherReport._id}`)
+                .send({ description: 'Updated report' });
+
+            expect(res.statusCode).toEqual(403);
+        });
+    });
+
+    describe('PUT /api/reports/admin/:id', () => {
+        let adminUser, report;
+
+        beforeEach(async () => {
+            adminUser = new User({ name: 'Admin User', email: 'admin@test.com', password: 'password', role: 'admin' });
+            await adminUser.save();
+
+            const regularUser = new User({ name: 'Test User', email: 'test@test.com', password: 'password' });
+            await regularUser.save();
+
+            report = new Report({
+                instrument: 'test.com',
+                type: 'Fraudulent Website',
+                reviews: [{ user: regularUser._id, description: 'Initial review' }]
+            });
+            await report.save();
+
+            mockAuthMiddleware.protect.mockImplementation((req, res, next) => {
+                req.user = adminUser;
+                next();
+            });
+            mockAuthMiddleware.adminOnly.mockImplementation((req, res, next) => {
+                if (req.user.role === 'admin') {
+                    next();
+                } else {
+                    res.status(403).json({ message: 'Forbidden' });
+                }
+            });
+        });
+
+        it('should allow an admin to update any report', async () => {
+            const res = await request(app)
+                .put(`/api/reports/admin/${report._id}`)
+                .send({ riskLevel: 'high' });
+
+            expect(res.statusCode).toEqual(200);
+            expect(res.body.message).toBe('Report updated successfully.');
+            const updatedReport = await Report.findById(report._id);
+            expect(updatedReport.riskLevel).toBe('high');
+        });
+    });
+
+    describe('DELETE /api/reports/admin/:id', () => {
+        let adminUser, report;
+
+        beforeEach(async () => {
+            adminUser = new User({ name: 'Admin User', email: 'admin@test.com', password: 'password', role: 'admin' });
+            await adminUser.save();
+
+            const regularUser = new User({ name: 'Test User', email: 'test@test.com', password: 'password' });
+            await regularUser.save();
+
+            report = new Report({
+                instrument: 'test.com',
+                type: 'Fraudulent Website',
+                reviews: [{ user: regularUser._id, description: 'Initial review' }]
+            });
+            await report.save();
+
+            mockAuthMiddleware.protect.mockImplementation((req, res, next) => {
+                req.user = adminUser;
+                next();
+            });
+            mockAuthMiddleware.adminOnly.mockImplementation((req, res, next) => {
+                if (req.user.role === 'admin') {
+                    next();
+                } else {
+                    res.status(403).json({ message: 'Forbidden' });
+                }
+            });
+        });
+
+        it('should allow an admin to delete any report', async () => {
+            const res = await request(app)
+                .delete(`/api/reports/admin/${report._id}`);
+
+            expect(res.statusCode).toEqual(200);
+            expect(res.body.message).toBe('Report deleted successfully.');
+            const deletedReport = await Report.findById(report._id);
+            expect(deletedReport).toBeNull();
         });
     });
 });


### PR DESCRIPTION
This commit introduces the ability for users and admins to edit and delete reports with different permissions.

- Regular users can edit their own reports within one hour of creation.
- Admins can edit and delete any report at any time.

The `Report` model has been updated to include a `createdBy` field to track the creator of the report. The `reportController` has been updated with the new logic for updating and deleting reports, and the `reportRoutes` have been updated to expose the new endpoints.

Tests have been added to verify the new functionality.